### PR TITLE
fix: draw every geometry type in a GeoJSON dataset, not just the first

### DIFF
--- a/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/geometryGroups.test.ts
+++ b/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/geometryGroups.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+import { groupFeaturesByGeometry } from './geometryGroups'
+
+import type { Feature, FeatureCollection } from 'geojson'
+
+function fc(...features: Feature[]): FeatureCollection {
+  return { type: 'FeatureCollection', features }
+}
+
+const point: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'Point', coordinates: [0, 0] },
+}
+
+const multiPoint: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'MultiPoint', coordinates: [[0, 0], [1, 1]] },
+}
+
+const line: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] },
+}
+
+const multiLine: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'MultiLineString', coordinates: [[[0, 0], [1, 1]]] },
+}
+
+const polygon: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+}
+
+const multiPolygon: Feature = {
+  type: 'Feature',
+  properties: {},
+  geometry: { type: 'MultiPolygon', coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]]]] },
+}
+
+describe('groupFeaturesByGeometry', () => {
+  it('keeps every geometry family present in a mixed collection', () => {
+    const groups = groupFeaturesByGeometry(fc(polygon, line, point))
+    expect(groups.map(g => g.kind).sort()).toEqual(['lines', 'points', 'polygons'])
+  })
+
+  it('does not let the first feature decide the whole collection', () => {
+    const polygonFirst = groupFeaturesByGeometry(fc(polygon, point))
+    const pointFirst = groupFeaturesByGeometry(fc(point, polygon))
+    expect(polygonFirst.map(g => g.kind).sort()).toEqual(pointFirst.map(g => g.kind).sort())
+  })
+
+  it('puts each feature in its own group', () => {
+    const groups = groupFeaturesByGeometry(fc(polygon, line, point))
+    const points = groups.find(g => g.kind === 'points')
+    expect(points?.featureCollection.features).toEqual([point])
+  })
+
+  it('groups multi-geometries with their single counterparts', () => {
+    const groups = groupFeaturesByGeometry(fc(point, multiPoint, line, multiLine, polygon, multiPolygon))
+    expect(groups).toHaveLength(3)
+    for (const group of groups) {
+      expect(group.featureCollection.features).toHaveLength(2)
+    }
+  })
+
+  it('returns a single group for a collection of one family', () => {
+    const groups = groupFeaturesByGeometry(fc(polygon, polygon))
+    expect(groups).toHaveLength(1)
+    expect(groups[0].kind).toBe('polygons')
+    expect(groups[0].featureCollection.features).toHaveLength(2)
+  })
+
+  it('returns no groups for an empty collection', () => {
+    expect(groupFeaturesByGeometry(fc())).toEqual([])
+  })
+
+  it('ignores features with no geometry rather than throwing', () => {
+    const noGeometry = { type: 'Feature', properties: {}, geometry: null } as unknown as Feature
+    const groups = groupFeaturesByGeometry(fc(noGeometry, point))
+    expect(groups).toHaveLength(1)
+    expect(groups[0].kind).toBe('points')
+  })
+
+  it('ignores geometry types it cannot draw, such as GeometryCollection', () => {
+    const collection = {
+      type: 'Feature',
+      properties: {},
+      geometry: { type: 'GeometryCollection', geometries: [] },
+    } as unknown as Feature
+    const groups = groupFeaturesByGeometry(fc(collection, point))
+    expect(groups.map(g => g.kind)).toEqual(['points'])
+  })
+
+  it('orders groups so polygons draw beneath lines and points', () => {
+    const groups = groupFeaturesByGeometry(fc(point, line, polygon))
+    expect(groups.map(g => g.kind)).toEqual(['polygons', 'lines', 'points'])
+  })
+
+  it('carries the collection-level properties onto each group', () => {
+    const source: FeatureCollection = {
+      type: 'FeatureCollection',
+      bbox: [0, 0, 1, 1],
+      features: [polygon, point],
+    }
+    const groups = groupFeaturesByGeometry(source)
+    for (const group of groups) {
+      expect(group.featureCollection.bbox).toEqual([0, 0, 1, 1])
+      expect(group.featureCollection.type).toBe('FeatureCollection')
+    }
+  })
+})

--- a/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/geometryGroups.ts
+++ b/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/geometryGroups.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+import type { Feature, FeatureCollection } from 'geojson'
+
+/**
+ * The three geometry families the map can draw. MapLibre needs a different
+ * layer type for each, so a collection holding more than one family needs more
+ * than one layer — see {@link groupFeaturesByGeometry}.
+ */
+export type GeometryKind = 'polygons' | 'lines' | 'points'
+
+export interface GeometryGroup {
+  kind: GeometryKind
+  featureCollection: FeatureCollection
+}
+
+/** Draw order: polygons sit beneath lines, and lines beneath points. */
+const DRAW_ORDER: GeometryKind[] = ['polygons', 'lines', 'points']
+
+const KIND_BY_GEOMETRY_TYPE: Record<string, GeometryKind> = {
+  Point: 'points',
+  MultiPoint: 'points',
+  LineString: 'lines',
+  MultiLineString: 'lines',
+  Polygon: 'polygons',
+  MultiPolygon: 'polygons',
+}
+
+/**
+ * Split a collection into one group per geometry family present.
+ *
+ * The renderer used to read `features[0].geometry.type` and draw the whole
+ * collection that way, so a file mixing polygons with points or lines lost
+ * everything that did not match its first feature — silently, with no error.
+ * Grouping first means each family gets its own layer.
+ *
+ * Features with no geometry, and geometry types the map cannot draw (such as
+ * GeometryCollection), are left out rather than throwing.
+ *
+ * Groups come back in draw order, and each keeps any collection-level fields
+ * (`bbox` and friends) from the source.
+ */
+export function groupFeaturesByGeometry(featureCollection: FeatureCollection): GeometryGroup[] {
+  const byKind = new Map<GeometryKind, Feature[]>()
+
+  for (const feature of featureCollection.features) {
+    const geometryType = feature?.geometry?.type
+    if (!geometryType) continue
+
+    const kind = KIND_BY_GEOMETRY_TYPE[geometryType]
+    if (!kind) continue
+
+    const existing = byKind.get(kind)
+    if (existing) existing.push(feature)
+    else byKind.set(kind, [feature])
+  }
+
+  return DRAW_ORDER.flatMap((kind) => {
+    const features = byKind.get(kind)
+    if (!features) return []
+    return [{
+      kind,
+      featureCollection: { ...featureCollection, type: 'FeatureCollection' as const, features },
+    }]
+  })
+}

--- a/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/index.tsx
+++ b/src/core/components/viewers/map/src/MapLayers/src/OpenDataLayer/src/index.tsx
@@ -15,6 +15,7 @@ import { fitGeoJsonBounds } from "../../../../../utils/fitGeojsonBounds";
 import { MapLayerClickPriority } from "../../../../../utils/MapEventManager/MapClickManager";
 import MapFeaturePopoverMenu from "../../../../MapFeaturePopoverMenu";
 
+import { groupFeaturesByGeometry } from "./geometryGroups";
 import { WmsTimeControl } from "./WmsTimeControl";
 
 import type { Building } from '../../../../../../../../types/dbTypes';
@@ -107,9 +108,6 @@ const GeoJsonDatasetLayer = React.memo(({ dataset, index, onLayerReady, onLayerR
     const layerContent = React.useMemo(() => {
         if (!featureCollection || featureCollection.features.length === 0) return null;
 
-        const geometryType = featureCollection.features[0]?.geometry?.type;
-        if (!geometryType) return null;
-
         // ── colour resolution ──
         let layerColor: any = dataset.layerColor?.color || '#0d9488';
         let numericFieldName: string | undefined;
@@ -179,27 +177,34 @@ const GeoJsonDatasetLayer = React.memo(({ dataset, index, onLayerReady, onLayerR
             }),
         };
 
-        // ── build layer props per geometry type ──
+        // ── build one layer set per geometry family present ──
+        // MapLibre needs a different layer type for points, lines and polygons,
+        // and clustering only works on a points-only source — so each family
+        // gets its own source. Reading features[0] and picking a single branch
+        // silently dropped every other geometry in a mixed collection.
         const registeredIds: string[] = [];
+        const sources: React.ReactNode[] = [];
 
-        if (geometryType === 'Point' || geometryType === 'MultiPoint') {
-            const paint = {
-                'circle-radius': 6,
-                'circle-color': layerColor,
-                'circle-opacity': 0.8,
-                'circle-stroke-width': 2,
-                'circle-stroke-color': '#ffffff',
-            };
-            registeredIds.push(`${dataset.name}-unclustered-point`);
+        for (const group of groupFeaturesByGeometry(enrichedFC)) {
+            const sourceId = `${dataset.name}-source-${group.kind}`;
+            const sourceKey = `${index}-${sourceId}`;
 
-            return {
-                registeredIds,
-                jsx: (
+            if (group.kind === 'points') {
+                const paint = {
+                    'circle-radius': 6,
+                    'circle-color': layerColor,
+                    'circle-opacity': 0.8,
+                    'circle-stroke-width': 2,
+                    'circle-stroke-color': '#ffffff',
+                };
+                registeredIds.push(`${dataset.name}-unclustered-point`);
+
+                sources.push(
                     <Source
-                        id={`${dataset.name}-source`}
-                        key={`${index}-${dataset.name}-source`}
+                        id={sourceId}
+                        key={sourceKey}
                         type="geojson"
-                        data={enrichedFC}
+                        data={group.featureCollection}
                         cluster={true}
                         clusterMaxZoom={11}
                         clusterRadius={50}
@@ -231,62 +236,58 @@ const GeoJsonDatasetLayer = React.memo(({ dataset, index, onLayerReady, onLayerR
                             type="circle"
                             paint={paint}
                         />
-                    </Source>
-                ),
-            };
-        }
+                    </Source>,
+                );
+                continue;
+            }
 
-        if (geometryType === 'LineString' || geometryType === 'MultiLineString') {
-            const mainId = `${dataset.name}-line`;
-            registeredIds.push(mainId);
-            return {
-                registeredIds,
-                jsx: (
+            if (group.kind === 'lines') {
+                const mainId = `${dataset.name}-line`;
+                registeredIds.push(mainId);
+                sources.push(
                     <Source
-                        id={`${dataset.name}-source`}
-                        key={`${index}-${dataset.name}-source`}
+                        id={sourceId}
+                        key={sourceKey}
                         type="geojson"
-                        data={enrichedFC}
+                        data={group.featureCollection}
                     >
                         <Layer
                             id={mainId}
                             type="line"
                             paint={{ 'line-color': layerColor, 'line-width': 3, 'line-opacity': 1 }}
                         />
-                    </Source>
-                ),
-            };
-        }
+                    </Source>,
+                );
+                continue;
+            }
 
-        if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
             const fillId = `${dataset.name}-fill`;
             const outlineId = `${dataset.name}-outline`;
             registeredIds.push(fillId, outlineId);
-            return {
-                registeredIds,
-                jsx: (
-                    <Source
-                        id={`${dataset.name}-source`}
-                        key={`${index}-${dataset.name}-source`}
-                        type="geojson"
-                        data={enrichedFC}
-                    >
-                        <Layer
-                            id={fillId}
-                            type="fill"
-                            paint={{ 'fill-color': layerColor, 'fill-opacity': 0.5 }}
-                        />
-                        <Layer
-                            id={outlineId}
-                            type="line"
-                            paint={{ 'line-color': '#ffffff', 'line-width': 2 }}
-                        />
-                    </Source>
-                ),
-            };
+            sources.push(
+                <Source
+                    id={sourceId}
+                    key={sourceKey}
+                    type="geojson"
+                    data={group.featureCollection}
+                >
+                    <Layer
+                        id={fillId}
+                        type="fill"
+                        paint={{ 'fill-color': layerColor, 'fill-opacity': 0.5 }}
+                    />
+                    <Layer
+                        id={outlineId}
+                        type="line"
+                        paint={{ 'line-color': '#ffffff', 'line-width': 2 }}
+                    />
+                </Source>,
+            );
         }
 
-        return null;
+        if (sources.length === 0) return null;
+
+        return { registeredIds, jsx: <>{sources}</> };
     }, [featureCollection, dataset.name, dataset.layerColor, dataset.selectedFieldName, dataset.fields, index]);
 
     // Register / unregister interactive layer IDs with the parent


### PR DESCRIPTION
## Description

The open-data layer picked how to draw a whole GeoJSON dataset from the geometry type of its **first feature**, then built only that one kind of layer. Everything else in the collection was still loaded into the map source, but there was no layer to draw it, so it silently never appeared — no error, no warning.

Reproduced both ways against the same file: a collection starting with a polygon drew its polygons and dropped its points and lines; the same collection reordered to start with a point did the opposite.

The fix groups features by geometry type and gives each group that is actually present its own source and layer set.

- Layer ids are unchanged, so click handling and popups keep working.
- Points keep their own source, so clustering still works.
- New pure module `geometryGroups.ts` does the grouping, with its own tests (written before the implementation).

Files: `src/core/components/MapLayers/src/OpenDataLayer/src/index.tsx`, plus new `geometryGroups.ts` and `geometryGroups.test.ts` (+248 / −61).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in the footer)
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:`, `chore:`)

## Checklist

- [x] This PR targets the **`dev`** branch (not `main`).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I ran `yarn lint` and `yarn test:unit` locally and they pass.
- [x] I added or updated tests where appropriate.
- [ ] I updated documentation where appropriate. <!-- no doc change needed: internal layer construction, no API change -->
- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/collabdt/core/blob/main/CLA.md) and will sign via the CLA bot on this PR.

## Screenshots / notes

**Verified in the browser**, not just by unit test. Against a saved 6-feature dataset that previously drew polygons only, all six features now draw — 3 polygons, 1 line, 2 points — with no errors in the app log.

Local results on this branch:

- `yarn test:unit` — 83 files / 738 tests pass (includes 10 new tests for `geometryGroups`)
- `yarn lint` — 0 errors (43 pre-existing warnings, unchanged)

The branch is one commit on top of current `dev`.
