### PR TITLE
fix: organizational datasets list for members and load from the owning org

### DIFF
--- a/src/core/components/viewers/map/datasets/index.tsx
+++ b/src/core/components/viewers/map/datasets/index.tsx
@@ -6,7 +6,6 @@
 // Icons
 import * as LR from 'lucide-react'
 // Dependencies
-import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import * as  React from 'react'
 
@@ -49,12 +48,11 @@ import DatasetSkeleton from './DatasetSkeleton'
 import Filters from './Filters'
 import RowActions from './RowActions'
 import { builtinLiveDatasets } from './src/builtinLiveDatasets'
-import { fetchLocalDatasets } from './src/localDatasets'
-import { fetchOrganizationalMinioDatasets } from './src/minioDatasets'
-import { datasetVisibleForOrg, getOrgVisibility } from './src/orgVisibility'
-import { buildPublishedCatalogMap, stampPublished, type PublishedCatalogEntry } from './src/publishedTiles'
+import { datasetVisibleForOrg } from './src/orgVisibility'
+import { stampPublished } from './src/publishedTiles'
 import { useDatasetsForPortals } from './src/useDatasetsForPortals'
 import { useFastDatasetCache } from './src/useFastDatasetCache'
+import { useOrganizationalDatasets } from './src/useOrganizationalDatasets'
 import { handleFavouriteDataset } from './utils'
 
 import type { Dataset } from '../../../../types/datasetTypes'
@@ -90,10 +88,18 @@ export default function Datasets({ isOpen, setIsOpenAction, organization, minioB
   const { state: menusState } = React.useContext(MenusContext)
   const { rowsPerPage } = menusState.menus
 
-  const pathname = usePathname()
-  // Pass the instance's real organization — the path-prefix fallback only knows
-  // five orgs, so newer ones could not see their own datasets.
-  const orgVisibility = React.useMemo(() => getOrgVisibility(pathname, org?.id), [pathname, org?.id])
+  const { datasets: orgDatasets, publishedCatalog, orgVisibility } = useOrganizationalDatasets({
+    organization: org,
+    minioBaseUrl,
+    martinBaseUrl,
+    refreshNonce: datasetState.datasets.orgRefreshNonce,
+  })
+
+  React.useEffect(() => {
+    // Skip the pre-load null so a reopen keeps the previous list on screen.
+    if (!orgDatasets) return
+    datasetDispatch({ type: 'SET_DATASETS', payload: { datasets: orgDatasets } })
+  }, [datasetDispatch, orgDatasets])
 
   // UI State
   const [view, setView] = React.useState<'table' | 'detail'>('table')
@@ -103,10 +109,6 @@ export default function Datasets({ isOpen, setIsOpenAction, organization, minioB
   const [appliedFilters, setAppliedFilters] = React.useState<{ countrySubdivisions: string[], municipalities: string[], types: string[], sources: string[] }>({ countrySubdivisions: [], municipalities: [], types: [], sources: [] })
   const [currentTab, setCurrentTab] = React.useState('all')
   const [isAddPortalOpen, setIsAddPortalOpen] = React.useState(false)
-  // Open-data datasets already published to Martin tiles, keyed by
-  // "{portalId}:{datasetId}". Lets the original portal entry (National/Applied/
-  // All tabs) show as converted, not just the organizational-list copy.
-  const [publishedCatalog, setPublishedCatalog] = React.useState<Map<string, PublishedCatalogEntry>>(new Map())
   const showMunicipalTab = React.useMemo(() => Boolean(municipality), [municipality])
 
   const { openDataPortals: municipalPortals } = useOpenDataPortalsByMunicipality(municipality)
@@ -143,93 +145,6 @@ export default function Datasets({ isOpen, setIsOpenAction, organization, minioB
   const municipal = useDatasetsForPortals(filteredMunicipalPortals, { rowsPerPage })
   const subdivision = useDatasetsForPortals(filteredSubdivisionPortals, { rowsPerPage })
   const national = useDatasetsForPortals(filteredNationalPortals, { rowsPerPage })
-  React.useEffect(() => {
-    const loadOrganizationalDatasets = async () => {
-      // First, refresh the published-catalog lookup (a fast /api/files read) so
-      // converted open-data datasets flip promptly across every tab — ahead of
-      // the slower Martin tile-sampling below. Non-fatal on failure.
-      try {
-        const filesRes = await fetch('/api/files')
-        if (filesRes.ok) {
-          const body = await filesRes.json()
-          const rows = Array.isArray(body?.files) ? body.files : []
-          setPublishedCatalog(buildPublishedCatalogMap(rows))
-        }
-      }
-      catch (err) {
-        console.warn('Failed to refresh published-catalog map:', err)
-      }
-
-      // Two parallel sources: Martin vector tiles (if configured) and MinIO-
-      // backed GeoJSON uploads (the "Add Dataset" path). Errors from either
-      // are isolated so a failure on one side does not block the other.
-      const martinBaseUrlClean = (martinBaseUrl ?? '').replace(/\/+$/, '')
-
-      const martinPromise: Promise<Dataset[]> = martinBaseUrlClean
-        ? (async () => {
-            const datasetsUrl = martinBaseUrlClean.includes('/tiles/index.json')
-              ? martinBaseUrlClean
-              : `${martinBaseUrlClean}/tiles/index.json`
-
-            const localPortal = {
-              id: -1,
-              name: 'Organizational Datasets',
-              apiUrl: datasetsUrl,
-              dataManagementSystem: 'Other' as const,
-              countrySubdivision: null,
-              municipality: null,
-              group: 'Organizational' as const,
-            }
-
-            try {
-              return await fetchLocalDatasets(localPortal as any)
-            }
-            catch (err) {
-              console.error('Failed to load Martin organizational datasets:', err)
-              return []
-            }
-          })()
-        : Promise.resolve([])
-
-      if (!martinBaseUrlClean) {
-        console.warn('NEXT_PUBLIC_MARTIN_SERVER_URL not configured — skipping Martin pre-load')
-      }
-
-      // The MinIO key prefix is the *session* organization (set server-side
-      // by the upload route), not orgVisibility.currentOrgId (which is
-      // path-derived and hardcoded for admin routes like /cdt).
-      const sessionOrgId = typeof org?.id === 'number'
-        ? org.id
-        : Number.parseInt(String(org?.id ?? ''), 10)
-
-      // Martin must resolve first so MinIO suppression can check live catalog
-      // membership — prevents "file disappeared" during the publish→restart gap.
-      const martinDatasets = await martinPromise
-      const publishedTilesInCatalog = new Set<string>(
-        martinDatasets.map(d => typeof d.id === 'string' ? d.id : '').filter(Boolean),
-      )
-
-      const minioDatasets: Dataset[] = Number.isFinite(sessionOrgId)
-        ? await fetchOrganizationalMinioDatasets(sessionOrgId, publishedTilesInCatalog, minioBaseUrl).catch((err) => {
-            console.error('Failed to load MinIO organizational datasets:', err)
-            return []
-          })
-        : []
-
-      const combined = [...martinDatasets, ...minioDatasets]
-      const visibleOrgDatasets = combined.filter(ds => datasetVisibleForOrg(ds, orgVisibility))
-
-      if (visibleOrgDatasets.length === 0) {
-        console.warn('No organizational datasets found')
-      }
-      datasetDispatch({
-        type: 'SET_DATASETS',
-        payload: { datasets: visibleOrgDatasets },
-      })
-    }
-
-    void loadOrganizationalDatasets()
-  }, [datasetDispatch, orgVisibility, org?.id, datasetState.datasets.orgRefreshNonce])
 
   // Stamp each portal list with published-tile identity so a converted open-data
   // dataset shows as converted on its own tab (National/Subdivision/Municipal),

--- a/src/core/components/viewers/map/datasets/index.tsx
+++ b/src/core/components/viewers/map/datasets/index.tsx
@@ -51,6 +51,7 @@ import RowActions from './RowActions'
 import { builtinLiveDatasets } from './src/builtinLiveDatasets'
 import { fetchLocalDatasets } from './src/localDatasets'
 import { fetchOrganizationalMinioDatasets } from './src/minioDatasets'
+import { datasetVisibleForOrg, getOrgVisibility } from './src/orgVisibility'
 import { buildPublishedCatalogMap, stampPublished, type PublishedCatalogEntry } from './src/publishedTiles'
 import { useDatasetsForPortals } from './src/useDatasetsForPortals'
 import { useFastDatasetCache } from './src/useFastDatasetCache'
@@ -58,61 +59,6 @@ import { handleFavouriteDataset } from './utils'
 
 import type { Dataset } from '../../../../types/datasetTypes'
 import type { Organization } from '../../../../types/dbTypes';
-
-type OrgVisibility = {
-  isAdmin: boolean
-  currentOrgId: number
-  allowedOrgIds: number[]
-}
-
-const ADMIN_ALLOWED_ORGS = [1, 2, 3, 4, 5, 6]
-const ORG_BY_PATH_PREFIX: Record<string, number> = {
-  '/envirocentre': 1,
-  '/dnd': 3,
-  '/canada': 4,
-  '/gac': 5,
-  '/carleton': 6,
-}
-
-function normalizeOrgId(org?: number | string | null) {
-  if (org === null || org === undefined) return undefined
-  const parsed = typeof org === 'number' ? org : Number.parseInt(String(org), 10)
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
-function getOrgVisibilityFromPath(pathname?: string | null): OrgVisibility {
-  const normalizedPath = (pathname || '').toLowerCase()
-  const firstSegment = normalizedPath.split('/').filter(Boolean)[0]
-  const prefix = firstSegment ? `/${firstSegment}` : ''
-
-  if (prefix === '/cdt') {
-    return {
-      isAdmin: true,
-      currentOrgId: 1,
-      allowedOrgIds: ADMIN_ALLOWED_ORGS,
-    }
-  }
-
-  const currentOrgId = ORG_BY_PATH_PREFIX[prefix] ?? 2
-  const allowedOrgIds = Array.from(new Set([2, currentOrgId]))
-
-  return {
-    isAdmin: false,
-    currentOrgId,
-    allowedOrgIds,
-  }
-}
-
-function datasetVisibleForOrg(dataset: Dataset, visibility: OrgVisibility) {
-  if (visibility.isAdmin) return true
-  if (dataset.group !== DatasetGroup.Organizational) return true
-
-  const orgId = normalizeOrgId(dataset.organization)
-  if (orgId === undefined) return false
-
-  return visibility.allowedOrgIds.includes(orgId)
-}
-
 
 type DatasetsProps = {
   isOpen: boolean
@@ -145,7 +91,9 @@ export default function Datasets({ isOpen, setIsOpenAction, organization, minioB
   const { rowsPerPage } = menusState.menus
 
   const pathname = usePathname()
-  const orgVisibility = React.useMemo(() => getOrgVisibilityFromPath(pathname), [pathname])
+  // Pass the instance's real organization — the path-prefix fallback only knows
+  // five orgs, so newer ones could not see their own datasets.
+  const orgVisibility = React.useMemo(() => getOrgVisibility(pathname, org?.id), [pathname, org?.id])
 
   // UI State
   const [view, setView] = React.useState<'table' | 'detail'>('table')

--- a/src/core/components/viewers/map/datasets/src/minioDatasets.test.ts
+++ b/src/core/components/viewers/map/datasets/src/minioDatasets.test.ts
@@ -69,6 +69,12 @@ describe('fetchOrganizationalMinioDatasets', () => {
     expect(ds.url).toBe(ds.sourceUrl)
   })
 
+  it('stamps each dataset with the organization it was fetched for', async () => {
+    mockFilesFetch([validRow])
+    const [ds] = await fetchOrganizationalMinioDatasets(42, new Set(), TEST_MINIO_URL)
+    expect(ds.organization).toBe(42)
+  })
+
   it('strips .geojson from the name and falls back to "Dataset {id}"', async () => {
     mockFilesFetch([
       validRow,

--- a/src/core/components/viewers/map/datasets/src/minioDatasets.ts
+++ b/src/core/components/viewers/map/datasets/src/minioDatasets.ts
@@ -107,6 +107,9 @@ export async function fetchOrganizationalMinioDatasets(
 
     datasets.push({
       id,
+      // Stamped so the map's org-visibility filter can tell whose dataset this
+      // is. Without it every rebuilt dataset is dropped for non-admin viewers.
+      organization: organizationId,
       name,
       type: 'Organizational',
       publisher: 'Organizational',

--- a/src/core/components/viewers/map/datasets/src/orgVisibility.test.ts
+++ b/src/core/components/viewers/map/datasets/src/orgVisibility.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+import { DatasetGroup } from '../../../../../types/dbTypes'
+
+import { datasetVisibleForOrg, getOrgVisibility } from './orgVisibility'
+
+import type { Dataset } from '../../../../../types/datasetTypes'
+
+function orgDataset(organization?: number): Dataset {
+  return {
+    name: 'roads',
+    dataManagementSystem: 'other',
+    group: DatasetGroup.Organizational,
+    organization,
+  } as Dataset
+}
+
+describe('getOrgVisibility', () => {
+  it('treats the /cdt path as admin', () => {
+    const v = getOrgVisibility('/cdt/map')
+    expect(v.isAdmin).toBe(true)
+  })
+
+  it('is not admin on an organization path', () => {
+    expect(getOrgVisibility('/carleton').isAdmin).toBe(false)
+  })
+
+  it('resolves a known path prefix to its organization', () => {
+    expect(getOrgVisibility('/carleton').currentOrgId).toBe(6)
+  })
+
+  it('always allows the shared organization 2', () => {
+    expect(getOrgVisibility('/carleton').allowedOrgIds).toContain(2)
+  })
+
+  it('prefers the supplied organization over the path prefix table', () => {
+    expect(getOrgVisibility('/arts-ottawa', 27).currentOrgId).toBe(27)
+  })
+
+  it('allows an organization that is absent from the path prefix table', () => {
+    expect(getOrgVisibility('/arts-ottawa', 27).allowedOrgIds).toContain(27)
+  })
+
+  it('falls back to the prefix table when no organization is supplied', () => {
+    expect(getOrgVisibility('/carleton', undefined).currentOrgId).toBe(6)
+  })
+
+  it('accepts a numeric string organization id', () => {
+    expect(getOrgVisibility('/arts-ottawa', '27').currentOrgId).toBe(27)
+  })
+})
+
+describe('datasetVisibleForOrg', () => {
+  it('shows every dataset to an admin', () => {
+    expect(datasetVisibleForOrg(orgDataset(99), getOrgVisibility('/cdt'))).toBe(true)
+  })
+
+  it('shows non-organizational datasets to everyone', () => {
+    const open = { name: 'x', dataManagementSystem: 'other', group: DatasetGroup.National } as Dataset
+    expect(datasetVisibleForOrg(open, getOrgVisibility('/carleton'))).toBe(true)
+  })
+
+  it('hides an organizational dataset belonging to another organization', () => {
+    expect(datasetVisibleForOrg(orgDataset(99), getOrgVisibility('/carleton'))).toBe(false)
+  })
+
+  it('hides an organizational dataset with no organization recorded', () => {
+    expect(datasetVisibleForOrg(orgDataset(undefined), getOrgVisibility('/carleton'))).toBe(false)
+  })
+
+  it("shows a member their own organization's dataset", () => {
+    expect(datasetVisibleForOrg(orgDataset(27), getOrgVisibility('/arts-ottawa', 27))).toBe(true)
+  })
+})

--- a/src/core/components/viewers/map/datasets/src/orgVisibility.ts
+++ b/src/core/components/viewers/map/datasets/src/orgVisibility.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+import { DatasetGroup } from '../../../../../types/dbTypes'
+
+import type { Dataset } from '../../../../../types/datasetTypes'
+
+/**
+ * Which organizations' datasets the current viewer may see.
+ *
+ * Shared by the Datasets panel and the map sidebar's Layers tab — both used to
+ * carry their own copy of this logic.
+ */
+export type OrgVisibility = {
+  isAdmin: boolean
+  currentOrgId: number
+  allowedOrgIds: number[]
+}
+
+const ADMIN_ALLOWED_ORGS = [1, 2, 3, 4, 5, 6]
+
+/** Legacy path→org lookup, kept as a fallback for instances that predate orgs being passed in. */
+const ORG_BY_PATH_PREFIX: Record<string, number> = {
+  '/envirocentre': 1,
+  '/dnd': 3,
+  '/canada': 4,
+  '/gac': 5,
+  '/carleton': 6,
+}
+
+/** The shared organization whose datasets every instance may see. */
+const SHARED_ORG_ID = 2
+
+export function normalizeOrgId(org?: number | string | null) {
+  if (org === null || org === undefined) return undefined
+  const parsed = typeof org === 'number' ? org : Number.parseInt(String(org), 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/**
+ * @param pathname - the current route; `/cdt` grants admin visibility.
+ * @param currentOrganizationId - the organization this instance actually belongs
+ *   to. Prefer this over {@link ORG_BY_PATH_PREFIX}: that table only lists five
+ *   organizations, so every organization added since silently fell back to the
+ *   shared org and its members could not see their own datasets.
+ */
+export function getOrgVisibility(
+  pathname?: string | null,
+  currentOrganizationId?: number | string | null,
+): OrgVisibility {
+  const normalizedPath = (pathname || '').toLowerCase()
+  const firstSegment = normalizedPath.split('/').filter(Boolean)[0]
+  const prefix = firstSegment ? `/${firstSegment}` : ''
+
+  if (prefix === '/cdt') {
+    return { isAdmin: true, currentOrgId: 1, allowedOrgIds: ADMIN_ALLOWED_ORGS }
+  }
+
+  const currentOrgId = normalizeOrgId(currentOrganizationId)
+    ?? ORG_BY_PATH_PREFIX[prefix]
+    ?? SHARED_ORG_ID
+  return {
+    isAdmin: false,
+    currentOrgId,
+    allowedOrgIds: Array.from(new Set([SHARED_ORG_ID, currentOrgId])),
+  }
+}
+
+export function datasetVisibleForOrg(dataset: Dataset, visibility: OrgVisibility) {
+  if (visibility.isAdmin) return true
+  if (dataset.group !== DatasetGroup.Organizational) return true
+
+  const orgId = normalizeOrgId(dataset.organization)
+  if (orgId === undefined) return false
+
+  return visibility.allowedOrgIds.includes(orgId)
+}

--- a/src/core/components/viewers/map/datasets/src/useOrganizationalDatasets.test.tsx
+++ b/src/core/components/viewers/map/datasets/src/useOrganizationalDatasets.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+
+const session = vi.hoisted(() => ({ organizationId: 2 as number | undefined }))
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/dnd' }))
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: '1', organizationId: session.organizationId } } }),
+}))
+
+import { useOrganizationalDatasets } from './useOrganizationalDatasets'
+
+const realFetch = global.fetch
+const TEST_MINIO_URL = 'https://minio.example.com/'
+
+/** The instance being viewed. On /dnd this is DND, organization 3. */
+const DND_INSTANCE = { id: 3, name: 'dnd' } as any
+
+/** An uploaded GeoJSON row as /api/files returns it. */
+const uploadedRow = {
+  id: 1,
+  type: 'map-file',
+  tag: 'organizational-dataset',
+  name: 'roads.geojson',
+  assetId: 'asset-123',
+  description: JSON.stringify({ bucket: 'pointclouds-demo', geometryType: 'lines' }),
+  uploadedAt: '2025-01-01',
+}
+
+beforeEach(() => {
+  session.organizationId = 2
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (url === '/api/files') {
+      return Promise.resolve({ ok: true, json: async () => ({ files: [uploadedRow] }) })
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`))
+  }) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  global.fetch = realFetch
+  vi.restoreAllMocks()
+})
+
+describe('useOrganizationalDatasets', () => {
+  it('builds the MinIO path from the org that owns the file, not the org being viewed', async () => {
+    // /api/files is scoped to the signed-in user's organization, and the upload
+    // route keys objects under that same org — so org 2 owns this file even
+    // though we are looking at DND's instance (org 3).
+    const { result } = renderHook(() => useOrganizationalDatasets({
+      organization: DND_INSTANCE,
+      minioBaseUrl: TEST_MINIO_URL,
+    }))
+
+    await waitFor(() => expect(result.current.datasets).toHaveLength(1))
+    expect(result.current.datasets[0].sourceUrl).toBe('https://minio.example.com/pointclouds-demo/2/asset-123')
+  })
+
+  it('stamps the dataset with the org that owns it', async () => {
+    const { result } = renderHook(() => useOrganizationalDatasets({
+      organization: DND_INSTANCE,
+      minioBaseUrl: TEST_MINIO_URL,
+    }))
+
+    await waitFor(() => expect(result.current.datasets).toHaveLength(1))
+    expect(result.current.datasets[0].organization).toBe(2)
+  })
+
+  it('drops a dataset whose owning org this instance may not see', async () => {
+    // Org 4 signed in, looking at DND (org 3). DND may see its own datasets and
+    // the shared org's, not org 4's — and the file would 404 here anyway, so
+    // hiding it beats listing an empty layer.
+    session.organizationId = 4
+
+    const { result } = renderHook(() => useOrganizationalDatasets({
+      organization: DND_INSTANCE,
+      minioBaseUrl: TEST_MINIO_URL,
+    }))
+
+    // Wait for the load to settle, not for fetch: fetch is called on the first
+    // tick, so an empty-list assertion against it would pass before the load
+    // had any chance to produce something.
+    await waitFor(() => expect(result.current.datasets).not.toBeNull())
+    expect(result.current.datasets).toEqual([])
+  })
+
+  it('fetches nothing from MinIO before the session has loaded', async () => {
+    session.organizationId = undefined
+
+    const { result } = renderHook(() => useOrganizationalDatasets({
+      organization: DND_INSTANCE,
+      minioBaseUrl: TEST_MINIO_URL,
+    }))
+
+    await waitFor(() => expect(console.warn).toHaveBeenCalledWith('No organizational datasets found'))
+    expect(result.current.datasets).toEqual([])
+    // Only the published-catalog read; no attempt at a MinIO object URL.
+    const urls = (global.fetch as any).mock.calls.map((c: unknown[]) => c[0])
+    expect(urls.every((u: string) => u === '/api/files')).toBe(true)
+  })
+
+  it('still reports visibility for the org being viewed, not the signed-in org', async () => {
+    const { result } = renderHook(() => useOrganizationalDatasets({
+      organization: DND_INSTANCE,
+      minioBaseUrl: TEST_MINIO_URL,
+    }))
+
+    await waitFor(() => expect(result.current.datasets).toHaveLength(1))
+    expect(result.current.orgVisibility.currentOrgId).toBe(3)
+  })
+})

--- a/src/core/components/viewers/map/datasets/src/useOrganizationalDatasets.ts
+++ b/src/core/components/viewers/map/datasets/src/useOrganizationalDatasets.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025 Collab Digital Twins
+
+import { usePathname } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import * as React from 'react'
+
+import { fetchLocalDatasets } from './localDatasets'
+import { fetchOrganizationalMinioDatasets } from './minioDatasets'
+import { datasetVisibleForOrg, getOrgVisibility, normalizeOrgId, type OrgVisibility } from './orgVisibility'
+import { buildPublishedCatalogMap, type PublishedCatalogEntry } from './publishedTiles'
+
+import type { Dataset } from '../../../../../types/datasetTypes'
+import type { Organization } from '../../../../../types/dbTypes'
+
+/**
+ * Loads the Organizational dataset list: Martin vector tiles plus the MinIO-
+ * backed GeoJSON uploads from "Add Dataset", filtered to what this viewer may
+ * see.
+ *
+ * Extracted from the Datasets panel so the two organization ids in play can be
+ * tested apart — see {@link useOrganizationalDatasets} for why they differ.
+ */
+export type UseOrganizationalDatasetsArgs = {
+  /** The organization this instance belongs to — i.e. the one being *viewed*. */
+  organization?: Organization
+  minioBaseUrl?: string
+  martinBaseUrl?: string
+  /** Bumped by the store to force a reload after an upload or a publish. */
+  refreshNonce?: unknown
+}
+
+export type UseOrganizationalDatasetsResult = {
+  /**
+   * `null` until the first load settles, so callers can leave the previous list
+   * on screen instead of blanking it while a reload is in flight. An empty
+   * array means "loaded, and there is nothing to show".
+   */
+  datasets: Dataset[] | null
+  publishedCatalog: Map<string, PublishedCatalogEntry>
+  /** Also used by the panel's other tabs to filter open-data lists. */
+  orgVisibility: OrgVisibility
+}
+
+export function useOrganizationalDatasets({
+  organization,
+  minioBaseUrl,
+  martinBaseUrl,
+  refreshNonce,
+}: UseOrganizationalDatasetsArgs): UseOrganizationalDatasetsResult {
+  const pathname = usePathname()
+
+  // Pass the instance's real organization — the path-prefix fallback only knows
+  // five orgs, so newer ones could not see their own datasets.
+  const orgVisibility = React.useMemo(
+    () => getOrgVisibility(pathname, organization?.id),
+    [pathname, organization?.id],
+  )
+
+  // Two different organizations are in play, and they must not be confused:
+  //
+  //   owningOrgId — whose files these are. `/api/files` only ever returns the
+  //     signed-in user's organization, and the upload route keys objects under
+  //     that same organization, so this is where the bytes actually live.
+  //   orgVisibility.currentOrgId — whose instance is being *looked at*, taken
+  //     from the address bar. That decides what the viewer is allowed to see.
+  //
+  // They differ whenever you view another organization's instance. Using the
+  // viewed organization to build the storage path asks for a file that was
+  // never written there: the dataset lists, then draws nothing.
+  const { data: sessionData } = useSession()
+  const owningOrgId = normalizeOrgId(sessionData?.user?.organizationId)
+
+  const [datasets, setDatasets] = React.useState<Dataset[] | null>(null)
+  // Open-data datasets already published to Martin tiles, keyed by
+  // "{portalId}:{datasetId}". Lets the original portal entry (National/Applied/
+  // All tabs) show as converted, not just the organizational-list copy.
+  const [publishedCatalog, setPublishedCatalog] = React.useState<Map<string, PublishedCatalogEntry>>(new Map())
+
+  React.useEffect(() => {
+    const loadOrganizationalDatasets = async () => {
+      // First, refresh the published-catalog lookup (a fast /api/files read) so
+      // converted open-data datasets flip promptly across every tab — ahead of
+      // the slower Martin tile-sampling below. Non-fatal on failure.
+      try {
+        const filesRes = await fetch('/api/files')
+        if (filesRes.ok) {
+          const body = await filesRes.json()
+          const rows = Array.isArray(body?.files) ? body.files : []
+          setPublishedCatalog(buildPublishedCatalogMap(rows))
+        }
+      }
+      catch (err) {
+        console.warn('Failed to refresh published-catalog map:', err)
+      }
+
+      // Two parallel sources: Martin vector tiles (if configured) and MinIO-
+      // backed GeoJSON uploads (the "Add Dataset" path). Errors from either
+      // are isolated so a failure on one side does not block the other.
+      const martinBaseUrlClean = (martinBaseUrl ?? '').replace(/\/+$/, '')
+
+      const martinPromise: Promise<Dataset[]> = martinBaseUrlClean
+        ? (async () => {
+            const datasetsUrl = martinBaseUrlClean.includes('/tiles/index.json')
+              ? martinBaseUrlClean
+              : `${martinBaseUrlClean}/tiles/index.json`
+
+            const localPortal = {
+              id: -1,
+              name: 'Organizational Datasets',
+              apiUrl: datasetsUrl,
+              dataManagementSystem: 'Other' as const,
+              countrySubdivision: null,
+              municipality: null,
+              group: 'Organizational' as const,
+            }
+
+            try {
+              return await fetchLocalDatasets(localPortal as any)
+            }
+            catch (err) {
+              console.error('Failed to load Martin organizational datasets:', err)
+              return []
+            }
+          })()
+        : Promise.resolve([])
+
+      if (!martinBaseUrlClean) {
+        console.warn('NEXT_PUBLIC_MARTIN_SERVER_URL not configured — skipping Martin pre-load')
+      }
+
+      // Martin must resolve first so MinIO suppression can check live catalog
+      // membership — prevents "file disappeared" during the publish→restart gap.
+      const martinDatasets = await martinPromise
+      const publishedTilesInCatalog = new Set<string>(
+        martinDatasets.map(d => typeof d.id === 'string' ? d.id : '').filter(Boolean),
+      )
+
+      const minioDatasets: Dataset[] = owningOrgId !== undefined
+        ? await fetchOrganizationalMinioDatasets(owningOrgId, publishedTilesInCatalog, minioBaseUrl).catch((err) => {
+            console.error('Failed to load MinIO organizational datasets:', err)
+            return []
+          })
+        : []
+
+      const combined = [...martinDatasets, ...minioDatasets]
+      const visibleOrgDatasets = combined.filter(ds => datasetVisibleForOrg(ds, orgVisibility))
+
+      if (visibleOrgDatasets.length === 0) {
+        console.warn('No organizational datasets found')
+      }
+      setDatasets(visibleOrgDatasets)
+    }
+
+    void loadOrganizationalDatasets()
+  }, [orgVisibility, owningOrgId, minioBaseUrl, martinBaseUrl, refreshNonce])
+
+  return { datasets, publishedCatalog, orgVisibility }
+}

--- a/src/core/components/viewers/map/src/MapSidebar/src/LayersTab/index.tsx
+++ b/src/core/components/viewers/map/src/MapSidebar/src/LayersTab/index.tsx
@@ -16,6 +16,7 @@ import { DatasetsContext, MenusContext, useMapContext } from '../../../../../../
 import { DatasetGroup } from '../../../../../../../types/dbTypes'
 import { ViewerSidebarPanel } from '../../../../../../ui/ViewerSidebar/Panel'
 import { fetchLocalDatasets } from '../../../../datasets/src/localDatasets'
+import { datasetVisibleForOrg, getOrgVisibility } from '../../../../datasets/src/orgVisibility'
 import { useDatasetsForPortals } from '../../../../datasets/src/useDatasetsForPortals'
 
 import { AppliedDatasetsSection } from './src/AppliedDatasetsSection'
@@ -23,48 +24,6 @@ import { AvailableDatasetsSection } from './src/AvailableDatasetsSection'
 
 import type { Dataset } from '../../../../../../../types/datasetTypes'
 import type { Organization } from '../../../../../../../types/dbTypes';
-
-type OrgVisibility = {
-  isAdmin: boolean
-  currentOrgId: number
-  allowedOrgIds: number[]
-}
-
-const ADMIN_ALLOWED_ORGS = [1, 2, 3, 4, 5, 6]
-const ORG_BY_PATH_PREFIX: Record<string, number> = {
-  '/envirocentre': 1,
-  '/dnd': 3,
-  '/canada': 4,
-  '/gac': 5,
-  '/carleton': 6,
-}
-
-function normalizeOrgId(org?: number | string | null) {
-  if (org === null || org === undefined) return undefined
-  const parsed = typeof org === 'number' ? org : Number.parseInt(String(org), 10)
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
-function getOrgVisibilityFromPath(pathname?: string | null): OrgVisibility {
-  const normalizedPath = (pathname || '').toLowerCase()
-  const firstSegment = normalizedPath.split('/').filter(Boolean)[0]
-  const prefix = firstSegment ? `/${firstSegment}` : ''
-
-  if (prefix === '/cdt') {
-    return { isAdmin: true, currentOrgId: 1, allowedOrgIds: ADMIN_ALLOWED_ORGS }
-  }
-
-  const currentOrgId = ORG_BY_PATH_PREFIX[prefix] ?? 2
-  return { isAdmin: false, currentOrgId, allowedOrgIds: Array.from(new Set([2, currentOrgId])) }
-}
-
-function datasetVisibleForOrg(dataset: Dataset, visibility: OrgVisibility) {
-  if (visibility.isAdmin) return true
-  if (dataset.group !== DatasetGroup.Organizational) return true
-  const orgId = normalizeOrgId(dataset.organization)
-  if (orgId === undefined) return false
-  return visibility.allowedOrgIds.includes(orgId)
-}
 
 const BLOCKLIST_URLS = [
   '/2021_statistics_canada_boundaries/featureserver',
@@ -112,7 +71,9 @@ export function LayersTab({ martinBaseUrl, organization }: { martinBaseUrl?: str
   const { rowsPerPage } = menusState.menus
 
   const pathname = usePathname()
-  const orgVisibility = React.useMemo(() => getOrgVisibilityFromPath(pathname), [pathname])
+  // Pass the instance's real organization — see getOrgVisibility for why the
+  // path-prefix fallback alone is not enough.
+  const orgVisibility = React.useMemo(() => getOrgVisibility(pathname, org?.id), [pathname, org?.id])
 
   const { openDataPortals: municipalPortals } = useOpenDataPortalsByMunicipality(municipality)
   const { openDataPortals: subdivisionPortals } = useOpenDataPortalsByCountrySubdivision(countrySubdivision)


### PR DESCRIPTION
## Description

Two related fixes for organizational datasets in the map Datasets panel. Together they make an uploaded dataset both appear in the list *and* draw on the map.

**1. `fix: org dataset visibility for non-admin members`**

Which datasets a viewer may see was decided from a hardcoded five-entry table mapping a URL path prefix to an organization id. Any organization added after that table was written could not see its own datasets. The instance's real organization id is now passed in, and the path-prefix table remains only as a fallback. Extracted into `orgVisibility.ts` so the rule is testable on its own.

**2. `fix: build dataset storage path from the owning organization`**

An organizational dataset would list but draw nothing.

The upload route stores an object under the **signed-in user's** organization (`pointclouds-demo/<orgId>/<uuid>.geojson`). The read side rebuilt that path using the organization taken from the **web address** instead. Whenever you view another organization's instance, those two differ, so the app asked storage for a file that had never been written there; the fetch failed and the layer stayed empty.

Two different organizations are in play and the old code put both in one variable, whose comment said the opposite of what it did:

- **the owning organization** — whose files these are, and what the storage path must be built from. `/api/files` only ever returns the signed-in user's organization, so this is available from the session.
- **the viewed organization** — taken from the address bar, which decides what the viewer is allowed to see. This one is still correct for visibility.

Because the defect was in the wiring of a React effect rather than in a pure function, no unit test could reach it. The effect was extracted into a `useOrganizationalDatasets` hook — matching the pattern already used in that folder — so the wiring itself is exercised by tests. The hook returns `null` until the first load settles, distinct from `[]`, so the panel keeps the previous list on screen instead of blanking during a reload.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in the footer)
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:`, `chore:`)

## Checklist

- [x] This PR targets the **`dev`** branch (not `main`).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I ran `yarn lint` and `yarn test:unit` locally and they pass.
- [x] I added or updated tests where appropriate.
- [ ] I updated documentation where appropriate.
- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/collabdt/core/blob/main/CLA.md) and will sign via the CLA bot on this PR.

## Screenshots / notes

**Verified locally on `dev` @ 37af1cc (rebased onto the merged #64):**

- `yarn test:unit` — 85 files, 757 tests, all passing.
- `yarn lint` — 0 errors, 43 warnings, all pre-existing and none in the changed files.
- **Checked in a running browser**, which is what this fix ultimately needed: an uploaded dataset now lists *and* draws both on its owning organization's instance and on another organization's instance. Before the fix the second case listed the dataset and drew nothing. The server log confirms the file is read under the owning organization, with no failed fetches.

**A note for reviewers on the tests.** The new tests were checked against the bug itself, not just run green: restoring the old line fails 4 of the 5 new tests. The 5th correctly keeps passing, because it guards visibility, which that line does not affect.

**Follow-up, not addressed here.** This class of bug goes away entirely if the upload's returned object key is stored rather than rebuilt from parts on read, the way organization logos already work. That needs a new stored field on the dataset record, so it is out of scope for this fix.
