### PR TITLE
fix: define NODE_AUTH_TOKEN for the release job so yarn can read the …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Only the publish needs this, but yarn 1.x expands every env placeholder in the .npmrc
+    # setup-node writes for `registry-url` and dies when one is undefined -- on `install`,
+    # `build` and `test:unit` alike. Empty is fine: reading a public package needs no auth.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -123,7 +128,6 @@ jobs:
       - name: Publish to npm
         if: steps.gate.outputs.release == 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.gate.outputs.version }}
         run: |
           if npm view "@collabdt/core@$VERSION" version >/dev/null 2>&1; then


### PR DESCRIPTION
…npmrc

<!-- Thanks for contributing to Collab Digital Twins! Please fill in the sections below. -->

## Description

<!-- What does this PR change, and why? Link any related issue, e.g. "Closes #123". -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in the footer)
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:`, `chore:`)

## Checklist

- [x] This PR targets the **`dev`** branch (not `main`).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I ran `yarn lint` and `yarn test:unit` locally and they pass.
- [x] I added or updated tests where appropriate.
- [x] I updated documentation where appropriate.
- [x] I have read and agree to the [Contributor License Agreement](https://github.com/collabdt/core/blob/main/CLA.md) and will sign via the CLA bot on this PR.

## Screenshots / notes

<!-- Optional: UI screenshots, migration notes, or anything reviewers should know. -->
