### PR TITLE
fix: keep a stayActive plugin mounted when its panel closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **A plugin tool that sets `stayActive` now keeps working after its panel is closed.**
+  The plugin host put a plugin's whole component inside the toolbar dropdown, and a
+  dropdown throws its contents away when it closes — so the plugin's cleanup ran and
+  whatever it had added to the map was removed. Core's own stay-active tools were never
+  affected, because they keep their work in the component the toolbar mounts and put only
+  menu items inside the dropdown. A stay-active plugin now gets a panel the host owns:
+  the plugin stays mounted and only the panel around it is hidden while closed.
+  `ToolbarSubmenu` is unchanged, so every other tool behaves exactly as before, and
+  plugin tools that do not set `stayActive` keep the existing dropdown. No plugin needs
+  editing to pick this up.
+
 ## [0.9.0] - 2026-09-08
 
 Consolidates the work previously tagged locally as 0.9.0 through 0.11.1. Those tags were

--- a/src/core/plugins/host/usePluginToolbarTools.test.tsx
+++ b/src/core/plugins/host/usePluginToolbarTools.test.tsx
@@ -2,11 +2,14 @@
 // Copyright (C) 2025 Collab Digital Twins
 
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import * as LR from 'lucide-react'
 import * as React from 'react'
 
+import { SubmenuContext } from '../../components/ToolbarSubmenu'
+
 import { usePluginToolbarTools } from './usePluginToolbarTools'
+
 
 import type { PluginContribution } from './provider'
 import type { Tool } from '../../types/tools'
@@ -91,6 +94,100 @@ test('keeps the registration icon and cursor on the tool', () => {
   expect(tool.icon).toBe(LR.Ruler)
   expect(tool.cursor).toBe('crosshair')
   expect(tool.stayActive).toBe(true)
+})
+
+function makeProbe() {
+  const state = { mounted: 0, cleanups: 0 }
+  function Probe() {
+    React.useEffect(() => {
+      state.mounted += 1
+      return () => {
+        state.cleanups += 1
+      }
+    }, [])
+    return <div>panel contents</div>
+  }
+  return { state, Probe }
+}
+
+function renderPluginTool(overrides: Partial<ToolbarContribution> = {}) {
+  contributions.current = [contribution(overrides)]
+
+  function Harness() {
+    const [openSubmenu, setOpenSubmenu] = React.useState<string | null>(null)
+    const value = React.useMemo(() => ({ openSubmenu, setOpenSubmenu }), [openSubmenu])
+    const [tool] = usePluginToolbarTools('bim.tools')
+    const Component = tool.component as React.ComponentType<{ tool: Tool }>
+    return (
+      <SubmenuContext.Provider value={value}>
+        <Component tool={tool} />
+      </SubmenuContext.Provider>
+    )
+  }
+
+  const utils = render(<Harness />)
+  return {
+    ...utils,
+    // Not `getByRole`: an open Radix menu aria-hides the button under test.
+    button: () => utils.container.querySelector('button') as HTMLElement,
+  }
+}
+
+// Radix arms its dismiss listener in a `setTimeout(0)`; a press in the same tick misses it.
+async function settle() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+}
+
+// jsdom has no `PointerEvent`, and the fallback `Event` carries no `button`, which Radix reads.
+function pressButton(element: HTMLElement) {
+  fireEvent(element, new MouseEvent('pointerdown', {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+  }))
+  fireEvent.click(element)
+}
+
+test('keeps a stayActive plugin working after its panel is closed', async () => {
+  const { state, Probe } = makeProbe()
+  const { button } = renderPluginTool({ stayActive: true, component: Probe })
+  await settle()
+
+  pressButton(button())
+  expect(state.mounted).toBe(1)
+
+  pressButton(button())
+
+  expect(state.cleanups).toBe(0)
+  expect(state.mounted).toBe(1)
+})
+
+test('hides a stayActive plugin\'s panel while it is closed', async () => {
+  const { Probe } = makeProbe()
+  const { button } = renderPluginTool({ stayActive: true, component: Probe })
+  await settle()
+
+  pressButton(button())
+  expect(screen.getByText('panel contents')).toBeVisible()
+
+  pressButton(button())
+
+  expect(screen.getByText('panel contents')).not.toBeVisible()
+})
+
+test('still tears down a plugin that did not ask to stay active', async () => {
+  const { state, Probe } = makeProbe()
+  const { button } = renderPluginTool({ component: Probe })
+  await settle()
+
+  pressButton(button())
+  expect(state.mounted).toBe(1)
+
+  pressButton(button())
+
+  expect(state.cleanups).toBe(1)
 })
 
 test('wraps the plugin component rather than letting it replace the toolbar button', () => {

--- a/src/core/plugins/host/usePluginToolbarTools.tsx
+++ b/src/core/plugins/host/usePluginToolbarTools.tsx
@@ -6,7 +6,8 @@
 import * as LR from 'lucide-react'
 import * as React from 'react'
 
-import { ToolbarSubmenu } from '../../components/ToolbarSubmenu'
+import { SubmenuContext, ToolbarSubmenu } from '../../components/ToolbarSubmenu'
+import { Button } from '../../components/ui/Button'
 
 import { resolvePluginIcon } from './pluginIcon'
 import { usePluginConfigs, usePluginContributions, type PluginContribution } from './provider'
@@ -82,6 +83,61 @@ function pluginToolId(contribution: PluginContribution<ToolbarCapability>) {
   return `plugin:${contribution.pluginId}:${contribution.id}` as const
 }
 
+// A stay-active plugin must outlive the dropdown, which destroys its children on close.
+const PluginStayActivePanel: React.FC<{
+  children: React.ReactNode
+  tool: Tool
+}> = ({ children, tool }) => {
+  const { openSubmenu, setOpenSubmenu } = React.useContext(SubmenuContext)
+  const isOpen = openSubmenu === tool.id
+  const panelId = React.useId()
+  const containerRef = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpenSubmenu(null)
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpenSubmenu(null)
+    }
+
+    // Armed while closed, this would read the press that opens the panel as an outside press.
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, setOpenSubmenu])
+
+  return (
+    <div ref={containerRef} className="relative flex items-center">
+      <Button
+        size="default"
+        variant="ghost"
+        className="flex flex-row justify-center items-center px-1 pointer-events-auto text-primary-dark"
+        title={tool.title}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => setOpenSubmenu(isOpen ? null : tool.id)}
+      >
+        <tool.icon />
+        <LR.ChevronDown className={`-ml-2 transition-all duration-200 scale-75 ${isOpen ? 'rotate-180' : ''}`} />
+      </Button>
+      {/* Opens upward because the toolbar is pinned to the bottom of the viewport. */}
+      <div
+        id={panelId}
+        hidden={!isOpen}
+        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 min-w-[8rem] max-h-[60vh] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md pointer-events-auto"
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
 /**
  * Wrap a plugin's component into a real toolbar entry.
  *
@@ -102,13 +158,17 @@ function wrapPluginComponent(
   const Component = contribution.component as unknown as React.ComponentType<Record<string, unknown>>
 
   function PluginToolboxItem({ tool, ...rest }: React.ComponentProps<ToolComponent>) {
-    return (
-      <ToolbarSubmenu tool={tool}>
-        <PluginScopeProvider pluginId={contribution.pluginId} config={readConfig()}>
-          <Component tool={tool} {...rest} />
-        </PluginScopeProvider>
-      </ToolbarSubmenu>
+    const panel = (
+      <PluginScopeProvider pluginId={contribution.pluginId} config={readConfig()}>
+        <Component tool={tool} {...rest} />
+      </PluginScopeProvider>
     )
+
+    if (tool.stayActive) {
+      return <PluginStayActivePanel tool={tool}>{panel}</PluginStayActivePanel>
+    }
+
+    return <ToolbarSubmenu tool={tool}>{panel}</ToolbarSubmenu>
   }
 
   PluginToolboxItem.displayName = `PluginTool(${contribution.pluginId}/${contribution.id})`


### PR DESCRIPTION
## Description

`stayActive` had no effect for plugin tools. A plugin's map layer disappeared the moment its panel was closed.

The plugin host wrapped a plugin's whole component in `ToolbarSubmenu`, and a dropdown throws its children away when it closes — so the plugin's cleanup ran and whatever it had added to the map was removed. That is the opposite of what the flag asks for.

Core's own stay-active tools were never affected. They hold their work in the component the toolbar mounts and pass only menu items to the dropdown (`measureMapTool` is the example), so a close destroys the menu items and nothing else. Only the plugin path put everything inside.

**The fix.** A stay-active *plugin* now gets a panel the plugin host owns: the plugin mounts once and stays mounted, and only the panel around it is hidden while closed. `ToolbarSubmenu` is untouched, so every other tool behaves exactly as before, and plugin tools that do not set `stayActive` keep the existing dropdown. No plugin needs editing to pick this up.

**Why not just force-mount the Radix dropdown.** That was tried and it fails on three separate fronts, because three parts of Radix read "mounted" as "open": `disableOutsideScroll` is passed unconditionally, so react-remove-scroll's lock stays installed permanently and paints `pointer-events: none` across the page; the aria-hide is never undone; and `DismissableLayer` has no open check, so the next press on the trigger reads as a press *outside* the panel and closes it in the same gesture. Keeping the change on the plugin path avoids all three and leaves the shared dropdown alone.

**Verification.** The unit tests render the real plugin wrapper rather than feeding a hand-made child to `ToolbarSubmenu`, using a probe component that counts effect setups and teardowns — "is the plugin still alive" is the actual question, and a test that only checks the panel is on screen cannot answer it. Reverting the fix turns exactly those two tests red and leaves the other six green. Also confirmed in a browser against the Sentinel-2 imagery plugin: toggle layers, close the panel and the imagery stays on the map, reopen works, and disabling removes the layer.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in the footer)
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:`, `chore:`)

## Checklist

- [x] This PR targets the **`dev`** branch (not `main`).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I ran `yarn lint` and `yarn test:unit` locally and they pass. Lint: 0 errors (49 pre-existing warnings, none in the changed files). Tests: 174 files, 1618 tests passing.
- [x] I added or updated tests where appropriate.
- [ ] I updated documentation where appropriate. `CHANGELOG.md` is updated under `[Unreleased]`. No `cdt-docs` change is included because no export, prop or signature changes — but if the docs describe `stayActive` for plugin authors, they may be worth a note that it now holds for plugin tools and not only core ones.
- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/collabdt/core/blob/main/CLA.md) and will sign via the CLA bot on this PR.

## Screenshots / notes

Worth raising beyond this fix: the plugin host honoured a flag meaning "stay alive" while placing the plugin inside a container that destroys it on close, and nothing on the plugin path read the flag. Every plugin that needs to outlive its own panel hits this. If the preferred shape is different — for example having `ToolbarSubmenu` itself understand stay-active tools — happy to rework it; this version was chosen specifically to leave the shared dropdown untouched.

The panel's styling classes are copied from `DropdownMenuContent` rather than shared with it, so the two can drift. Exporting that class string from the dropdown module instead would be a small follow-up if you would prefer it.
