### PR TITLE
ci: only run the release job on the upstream repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ concurrency:
 
 jobs:
   release:
+    # Forks must never tag or publish: a fork run mints a second annotated tag object with
+    # the same name over the same commit, and every clone then conflicts on pull forever.
+    if: github.repository == 'CollabDigitalTwins/core'
     runs-on: ubuntu-latest
     # Only the publish needs this, but yarn 1.x expands every env placeholder in the .npmrc
     # setup-node writes for `registry-url` and dies when one is undefined -- on `install`,


### PR DESCRIPTION
<!-- Thanks for contributing to Collab Digital Twins! Please fill in the sections below. -->

## Description

<!-- What does this PR change, and why? Link any related issue, e.g. "Closes #123". -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in the footer)
- [ ] Documentation (`docs:`)
- [ ] Refactor / chore (`refactor:`, `chore:`)

## Checklist

- [ ] This PR targets the **`dev`** branch (not `main`).
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I ran `yarn lint` and `yarn test:unit` locally and they pass.
- [ ] I added or updated tests where appropriate.
- [ ] I updated documentation where appropriate.
- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/collabdt/core/blob/main/CLA.md) and will sign via the CLA bot on this PR.

## Screenshots / notes

<!-- Optional: UI screenshots, migration notes, or anything reviewers should know. -->
